### PR TITLE
Added node-syntaxhighlighter to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "socket.io": "0.9.14",
       "request": "2.x",
       "handlebars": "1.x",
-      "mkdirp": "0.3.5"
+      "mkdirp": "0.3.5",
+      "node-syntaxhighlighter": "0.8.1"
    },
    "devDependencies": {
       "grunt": "~0.3.17",


### PR DESCRIPTION
Adding node-syntaxhighlighter as it's required in [lib/server.js](https://github.com/qjcg/imdone/blob/master/lib/server.js#L11-L12).

When node-syntaxhighlighter is not installed, the user gets this on invocation :

``` sh
$ imdone -o

module.js:340
    throw err;
          ^
Error: Cannot find module 'node-syntaxhighlighter'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/lib/node_modules/imdone/lib/server.js:11:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
